### PR TITLE
center on reference in alignment in rmsd

### DIFF
--- a/src/biobox/classes/molecule.py
+++ b/src/biobox/classes/molecule.py
@@ -1327,7 +1327,7 @@ class Molecule(Structure):
 
         return d
 
-    def write_pdb(self, outname, conformations=[], index=[], split_struc=False dssp=False):
+    def write_pdb(self, outname, conformations=[], index=[], split_struc=False, dssp=False):
         '''
         overload superclass method for writing (multi)pdb.
 

--- a/src/biobox/classes/structure.py
+++ b/src/biobox/classes/structure.py
@@ -601,9 +601,10 @@ class Structure(object):
                 # apply rotation matrix
                 if align:
                     self.set_current(i)
-                    self.coordinates[i] += (COM1 - COM2) # should center on reference frame
+                    self.coordinates[i] -= COM2 # should center on origin
                     rotation = np.dot(V, Wt)
                     self.apply_transformation(rotation)
+                    self.coordinates[i] += COM1 # now should center on reference frame
 
                 reflect = float(
                     str(float(np.linalg.det(V) * np.linalg.det(Wt))))

--- a/src/biobox/classes/structure.py
+++ b/src/biobox/classes/structure.py
@@ -601,6 +601,7 @@ class Structure(object):
                 # apply rotation matrix
                 if align:
                     self.set_current(i)
+                    self.coordinates[i] += (COM1 - COM2) # should center on reference frame
                     rotation = np.dot(V, Wt)
                     self.apply_transformation(rotation)
 


### PR DESCRIPTION
Align method in rmsd_one_vs_all did not align translationally. Does anyone have any issues with this change?